### PR TITLE
Add support for holographic remoting in Unity editor

### DIFF
--- a/Assets/Scripts/SceneUnderstandingDataProvider.cs
+++ b/Assets/Scripts/SceneUnderstandingDataProvider.cs
@@ -8,7 +8,6 @@ namespace Microsoft.MixedReality.SceneUnderstanding.Samples.Unity
     using System.Linq;
     using System.Threading.Tasks;
     using UnityEngine;
-    using SceneUnderstanding = Microsoft.MixedReality.SceneUnderstanding;
 
     /// <summary>
     /// When running on device (HoloLens 2), this class interacts with the Scene Understanding runtime and keeps on retrieving the latest scene data.
@@ -97,12 +96,6 @@ namespace Microsoft.MixedReality.SceneUnderstanding.Samples.Unity
         {
             if (RunOnDevice)
             {
-                if (Application.isEditor)
-                {
-                    Logger.LogError("SceneUnderstandingDataProvider.Start: Running in editor with the RunOnDevice mode set is not supported.");
-                    return;
-                }
-
                 if (SceneUnderstanding.SceneObserver.IsSupported())
                 {
                     var access = await SceneUnderstanding.SceneObserver.RequestAccessAsync();

--- a/Assets/Scripts/SceneUnderstandingDataProvider.cs
+++ b/Assets/Scripts/SceneUnderstandingDataProvider.cs
@@ -98,7 +98,7 @@ namespace Microsoft.MixedReality.SceneUnderstanding.Samples.Unity
             {
                 if (Application.isEditor)
                 {
-                    Logger.LogWarning("You appear to be running in editor with the RunOnDevice mode, which is not supported.");
+                    Logger.LogWarning("SceneUnderstandingDataProvider.Start: Running in editor with the RunOnDevice mode set is not supported.");
                 }
 
                 if (SceneUnderstanding.SceneObserver.IsSupported())

--- a/Assets/Scripts/SceneUnderstandingDataProvider.cs
+++ b/Assets/Scripts/SceneUnderstandingDataProvider.cs
@@ -96,6 +96,11 @@ namespace Microsoft.MixedReality.SceneUnderstanding.Samples.Unity
         {
             if (RunOnDevice)
             {
+                if (Application.isEditor)
+                {
+                    Logger.LogWarning("You appear to be running in editor with the RunOnDevice mode, which is not supported.");
+                }
+
                 if (SceneUnderstanding.SceneObserver.IsSupported())
                 {
                     var access = await SceneUnderstanding.SceneObserver.RequestAccessAsync();

--- a/Assets/Scripts/SceneUnderstandingDisplayManager.cs
+++ b/Assets/Scripts/SceneUnderstandingDisplayManager.cs
@@ -6,7 +6,6 @@ namespace Microsoft.MixedReality.SceneUnderstanding.Samples.Unity
     using System.Collections;
     using System.Collections.Generic;
     using UnityEngine;
-    using SceneUnderstanding = Microsoft.MixedReality.SceneUnderstanding;
 
     /// <summary>
     /// Different rendering modes available for scene objects.

--- a/Assets/Scripts/SceneUnderstandingSaveDataUtils.cs
+++ b/Assets/Scripts/SceneUnderstandingSaveDataUtils.cs
@@ -1,5 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 
+// Work-around to disambiguate between Microsoft.Windows.* and Windows.*
+#if WINDOWS_UWP
+using WindowsStorage = Windows.Storage;
+#endif
+
 namespace Microsoft.MixedReality.SceneUnderstanding.Samples.Unity
 {
     using System;
@@ -9,7 +14,6 @@ namespace Microsoft.MixedReality.SceneUnderstanding.Samples.Unity
     using System.Text;
     using System.Threading.Tasks;
     using UnityEngine;
-    using SceneUnderstanding = Microsoft.MixedReality.SceneUnderstanding;
 
     /// <summary>
     /// Provides helper methods that allow one to save Scene Understanding data.
@@ -59,9 +63,9 @@ namespace Microsoft.MixedReality.SceneUnderstanding.Samples.Unity
             }
 
 #if WINDOWS_UWP
-            var folder = Windows.Storage.ApplicationData.Current.LocalFolder;
-            var file = await folder.CreateFileAsync(fileName, Windows.Storage.CreationCollisionOption.GenerateUniqueName);
-            await Windows.Storage.FileIO.WriteBytesAsync(file, serializedScene);
+            var folder = WindowsStorage.ApplicationData.Current.LocalFolder;
+            var file = await folder.CreateFileAsync(fileName, WindowsStorage.CreationCollisionOption.GenerateUniqueName);
+            await WindowsStorage.FileIO.WriteBytesAsync(file, serializedScene);
 #else
             var folder = Path.GetTempPath();
             var file = Path.Combine(folder, fileName);
@@ -196,9 +200,9 @@ namespace Microsoft.MixedReality.SceneUnderstanding.Samples.Unity
             }
 
 #if WINDOWS_UWP
-            var folder = Windows.Storage.ApplicationData.Current.LocalFolder;
-            var file = await folder.CreateFileAsync(fileName, Windows.Storage.CreationCollisionOption.GenerateUniqueName);
-            await Windows.Storage.FileIO.AppendTextAsync(file, str);
+            var folder = WindowsStorage.ApplicationData.Current.LocalFolder;
+            var file = await folder.CreateFileAsync(fileName, WindowsStorage.CreationCollisionOption.GenerateUniqueName);
+            await WindowsStorage.FileIO.AppendTextAsync(file, str);
 #else
             var folder = Path.GetTempPath();
             var file = Path.Combine(folder, fileName);

--- a/Assets/Scripts/SceneUnderstandingUtils.cs
+++ b/Assets/Scripts/SceneUnderstandingUtils.cs
@@ -4,7 +4,6 @@ namespace Microsoft.MixedReality.SceneUnderstanding.Samples.Unity
 {
     using System.Collections.Generic;
     using UnityEngine;
-    using SceneUnderstanding = Microsoft.MixedReality.SceneUnderstanding;
 
     /// <summary>
     /// Helper methods for Unity and Scene Understanding related operations.

--- a/Assets/packages.config
+++ b/Assets/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Microsoft.MixedReality.SceneUnderstanding" version="0.5.2042-rc" />
   <package id="Microsoft.VCRTForwarders.140" version="1.0.2-rc" />
+  <package id="Microsoft.Windows.MixedReality.DotNetWinRT" version="0.5.1037" />
 </packages>

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "com.unity.package-manager-ui": "2.0.8",
+    "com.unity.xr.windowsmr.metro": "1.0.15",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",


### PR DESCRIPTION
I modified the test app to support holographic remoting.
Changes include-

- Removed isEditor check from SceneUnderstandingDataProvider.
- Modified GetSceneToUnityTransform to use the MR .net adapter library (nuget package) to get the scene to unity transform on win32.

Note- SU remoting won't actually work in Unity without updates to the remoting player app and the wmr plugin for Unity. I currently have a pr out to fix the remoting library.

The version of the wmr plugin in manifest.json in this pr (1.0.15) will never reflect these changes, although it's possible to get it to work by manually replacing Microsoft.Holographic.AppRemoting.dll with a build that has the changes in it.